### PR TITLE
Update numpy requirements to 1.23.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ multidict==6.0.4
 multiprocess==0.70.14
 murmurhash==1.0.9
 numba==0.56.4
-numpy==1.20.3
+numpy==1.23.5
 packaging==23.0
 pandas==1.5.3
 pathy==0.10.1


### PR DESCRIPTION
Refers to this issue: https://github.com/HRNPH/AIwaifu/issues/45

Encountered issues while installing 